### PR TITLE
Add component search agent and chat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## New chat feature
+
+The chat interface understands a special command:
+
+```
+/component <name>
+```
+
+When used, an intermediate agent searches the UI component library for the best
+match and the front generation agent responds with a usage snippet.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/0261aa8b-c09f-4e67-9eb8-054daf92abd5) and click on Share -> Publish.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -3,6 +3,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Send, Copy, ThumbsUp, ThumbsDown } from 'lucide-react';
+import {
+  frontGenerationAgent,
+  intermediateAgent,
+} from '@/lib/agents';
 
 interface Message {
   id: number;
@@ -35,9 +39,19 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ messages, onAddMessage }) 
     const userMessage = input.trim();
     setInput('');
     onAddMessage(userMessage, 'user');
-    
+
     setIsTyping(true);
-    
+
+    if (userMessage.startsWith('/component ')) {
+      const query = userMessage.replace('/component ', '');
+      const { steps, best } = intermediateAgent(query);
+      steps.forEach((s) => onAddMessage(s, 'assistant'));
+      const genSteps = frontGenerationAgent(best);
+      genSteps.forEach((s) => onAddMessage(s, 'assistant'));
+      setIsTyping(false);
+      return;
+    }
+
     // Simulate AI response
     setTimeout(() => {
       const responses = [

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1,0 +1,56 @@
+export interface ComponentInfo {
+  name: string;
+  path: string;
+}
+
+// Import all UI component modules eagerly using Vite's glob import
+const modules = import.meta.glob('../components/ui/*.tsx', { eager: true });
+
+const components: ComponentInfo[] = Object.keys(modules).map((p) => {
+  const name = p.split('/').pop()?.replace('.tsx', '') || '';
+  return { name, path: p };
+});
+
+export interface SearchResult {
+  steps: string[];
+  best: ComponentInfo | null;
+}
+
+/**
+ * Intermediate agent that searches the component library for the best match.
+ */
+export function intermediateAgent(query: string): SearchResult {
+  const steps: string[] = [];
+  steps.push(`Analyzing query "${query}"`);
+
+  const matches = components.filter((c) =>
+    c.name.toLowerCase().includes(query.toLowerCase())
+  );
+  steps.push(`Found ${matches.length} matching component(s)`);
+
+  if (matches.length === 0) {
+    return { steps, best: null };
+  }
+
+  const best = matches[0];
+  steps.push(`Chose component "${best.name}" as best match`);
+  return { steps, best };
+}
+
+/**
+ * Front generation agent that produces a simple usage snippet.
+ */
+export function frontGenerationAgent(best: ComponentInfo | null): string[] {
+  const steps: string[] = [];
+  if (!best) {
+    steps.push('No matching component found.');
+    return steps;
+  }
+
+  steps.push(`Here is a simple usage example for ${best.name}:`);
+  steps.push('```tsx');
+  steps.push(`<${best.name} />`);
+  steps.push('```');
+  steps.push('Integrate this snippet with your backend logic as needed.');
+  return steps;
+}


### PR DESCRIPTION
## Summary
- implement intermediate and front generation agents for component lookup
- allow `/component <name>` command in ChatPanel to search components and show snippet
- document new chat command in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f1a125f40832b8e1e86625b6ea3be